### PR TITLE
Align calendar surfaces with MaterialTheme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.7.7'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
     
+    // Browser support for Custom Tabs
+    implementation 'androidx.browser:browser:1.7.0'
+
     // LiveData dependencies
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.7.0'
     implementation 'androidx.compose.runtime:runtime-livedata:1.6.1'

--- a/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
@@ -878,12 +878,12 @@ fun InfiniteCalendarPage(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        androidx.compose.material3.CircularProgressIndicator(color = Color.White)
+                        androidx.compose.material3.CircularProgressIndicator(color = colorScheme.onPrimary)
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
                             text = "Loading calendar activities...",
                             style = MaterialTheme.typography.bodyLarge,
-                            color = Color.White
+                            color = colorScheme.onPrimary
                         )
                     }
                 } else {
@@ -901,7 +901,7 @@ fun InfiniteCalendarPage(
                         Card(
                             modifier = Modifier.fillMaxSize(),
                             shape = RoundedCornerShape(24.dp, 24.dp, 0.dp, 0.dp),
-                            colors = CardDefaults.cardColors(containerColor = Color.White),
+                            colors = CardDefaults.cardColors(containerColor = colorScheme.surface),
                             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                         ) {
                             LazyColumn(
@@ -1108,7 +1108,7 @@ fun StravaMapDialog(
                 .fillMaxWidth()
                 .height(400.dp),
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.White),
+            colors = CardDefaults.cardColors(containerColor = colorScheme.surface),
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
         ) {
             Column(
@@ -1204,7 +1204,7 @@ private fun CalendarHeader(
                 text = "Training Calendar",
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color.White
+                color = colorScheme.onPrimary
             )
 
             // Refresh button
@@ -1221,7 +1221,7 @@ private fun CalendarHeader(
                         }
                     },
                 shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(containerColor = Color.White.copy(alpha = 0.9f)),
+                colors = CardDefaults.cardColors(containerColor = colorScheme.surfaceVariant),
                 elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
             ) {
                 Box(
@@ -1258,7 +1258,7 @@ private fun CalendarHeader(
                     }
                 },
             shape = RoundedCornerShape(12.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.White.copy(alpha = 0.9f)),
+            colors = CardDefaults.cardColors(containerColor = colorScheme.surfaceVariant),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
         ) {
             Row(
@@ -1803,7 +1803,7 @@ fun RoutePreview(
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
+        colors = CardDefaults.cardColors(containerColor = colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
@@ -244,6 +244,11 @@ fun InfiniteCalendarPage(
     val coroutineScope = rememberCoroutineScope()
     val colorScheme = MaterialTheme.colorScheme
     val extendedColors = MaterialTheme.extendedColors
+    val gradientContentColor = if (isSystemInDarkTheme()) {
+        colorScheme.onSurface
+    } else {
+        colorScheme.onPrimary
+    }
 
     // Sync live state
     var isSyncingLive by remember { mutableStateOf(false) }
@@ -878,12 +883,12 @@ fun InfiniteCalendarPage(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        androidx.compose.material3.CircularProgressIndicator(color = colorScheme.onPrimary)
+                        androidx.compose.material3.CircularProgressIndicator(color = gradientContentColor)
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
                             text = "Loading calendar activities...",
                             style = MaterialTheme.typography.bodyLarge,
-                            color = colorScheme.onPrimary
+                            color = gradientContentColor
                         )
                     }
                 } else {
@@ -896,6 +901,7 @@ fun InfiniteCalendarPage(
                             listState = listState,
                             coroutineScope = coroutineScope,
                             todayIndex = todayIndex,
+                            gradientContentColor = gradientContentColor,
                             onRefresh = { performSyncLive() })
                         // Calendar Content
                         Card(
@@ -1184,6 +1190,7 @@ private fun CalendarHeader(
     listState: LazyListState,
     coroutineScope: CoroutineScope,
     todayIndex: Int,
+    gradientContentColor: Color,
     onRefresh: () -> Unit = {}
 ) {
     val colorScheme = MaterialTheme.colorScheme
@@ -1204,7 +1211,7 @@ private fun CalendarHeader(
                 text = "Training Calendar",
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = colorScheme.onPrimary
+                color = gradientContentColor
             )
 
             // Refresh button

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -60,22 +59,18 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import com.example.fitnessapp.ui.theme.extendedColors
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -107,25 +102,20 @@ import java.util.TimeZone
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.background
-import androidx.compose.runtime.getValue
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.unit.em
-import androidx.compose.foundation.clickable
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.em
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -724,15 +714,15 @@ fun StravaActivityDetailScreen(
                                 ) {
                                     Column {
                                         Spacer(modifier = Modifier.height(8.dp))
-                                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                            val interactionSource = remember { MutableInteractionSource() }
-                                            val isPressed by interactionSource.collectIsPressedAsState()
-                                            val scale by animateFloatAsState(
-                                                targetValue = if (isPressed) 0.95f else 1f,
-                                                animationSpec = tween(100),
-                                                label = "stravaButtonScale"
-                                            )
+                                        val stravaButtonInteractionSource = remember { MutableInteractionSource() }
+                                        val isStravaButtonPressed by stravaButtonInteractionSource.collectIsPressedAsState()
+                                        val stravaButtonScale by animateFloatAsState(
+                                            targetValue = if (isStravaButtonPressed) 0.95f else 1f,
+                                            animationSpec = tween(durationMillis = 100),
+                                            label = "stravaButtonScale"
+                                        )
 
+                                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                                             Button(
                                                 onClick = {
                                                     val stravaUri = Uri.parse("strava://activities/$activityId")
@@ -779,13 +769,16 @@ fun StravaActivityDetailScreen(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
                                                     .height(56.dp)
-                                                    .graphicsLayer(scaleX = scale, scaleY = scale),
+                                                    .graphicsLayer(
+                                                        scaleX = stravaButtonScale,
+                                                        scaleY = stravaButtonScale
+                                                    ),
                                                 colors = ButtonDefaults.buttonColors(
                                                     containerColor = colorScheme.primary
                                                 ),
                                                 elevation = ButtonDefaults.buttonElevation(12.dp),
                                                 shape = RoundedCornerShape(16.dp),
-                                                interactionSource = interactionSource
+                                                interactionSource = stravaButtonInteractionSource
                                             ) {
                                                 Icon(
                                                     Icons.Default.Link,

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,6 +52,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import com.example.fitnessapp.ui.theme.extendedColors
@@ -216,6 +218,11 @@ fun StravaActivityDetailScreen(
 
     val colorScheme = MaterialTheme.colorScheme
     val extendedColors = MaterialTheme.extendedColors
+    val gradientContentColor = if (isSystemInDarkTheme()) {
+        colorScheme.onSurface
+    } else {
+        colorScheme.onPrimary
+    }
 
     var activity by remember { mutableStateOf<StravaActivity?>(null) }
     var mapViewData by remember { mutableStateOf<Map<String, String>?>(null) }
@@ -319,12 +326,15 @@ fun StravaActivityDetailScreen(
                     modifier = Modifier
                         .size(48.dp)
                         .clip(CircleShape)
-                        .background(Color.Transparent)
+                        .background(Color.Transparent),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        contentColor = gradientContentColor
+                    )
                 ) {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
                         contentDescription = "Navigate back to previous screen",
-                        tint = colorScheme.onPrimary
+                        tint = gradientContentColor
                     )
                 }
                 Row(
@@ -349,13 +359,13 @@ fun StravaActivityDetailScreen(
                             else -> Icons.Default.Speed
                         },
                         contentDescription = "Activity type: ${activity?.type}",
-                        tint = colorScheme.onPrimary,
+                        tint = gradientContentColor,
                         modifier = Modifier.size(24.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = activity?.name ?: "Activity Details",
-                        color = colorScheme.onPrimary,
+                        color = gradientContentColor,
                         fontWeight = FontWeight.Bold,
                         style = MaterialTheme.typography.titleLarge,
                         maxLines = 2,

--- a/app/src/main/java/com/example/fitnessapp/pages/home/TrainingDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/TrainingDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -112,6 +113,12 @@ fun TrainingDetailScreen(
     var error by remember { mutableStateOf<String?>(null) }
 
     val pullToRefreshState = rememberPullToRefreshState()
+    val colorScheme = MaterialTheme.colorScheme
+    val gradientContentColor = if (isSystemInDarkTheme()) {
+        colorScheme.onSurface
+    } else {
+        colorScheme.onPrimary
+    }
 
     // Add pull-to-refresh handler
     if (pullToRefreshState.isRefreshing) {
@@ -189,7 +196,7 @@ fun TrainingDetailScreen(
 
     val gradient = Brush.verticalGradient(
         colors = listOf(
-            MaterialTheme.colorScheme.primary,
+            colorScheme.primary,
             MaterialTheme.extendedColors.chartAltitude,
             MaterialTheme.extendedColors.gradientAccent
         )
@@ -218,7 +225,7 @@ fun TrainingDetailScreen(
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary
+                            tint = gradientContentColor
                         )
                     }
                 },
@@ -232,21 +239,21 @@ fun TrainingDetailScreen(
                                 else -> Icons.Default.Speed
                             },
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary,
+                            tint = gradientContentColor,
                             modifier = Modifier.size(24.dp)
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(
                             text = training.workout_name,
                             style = MaterialTheme.typography.headlineSmall,
-                            color = MaterialTheme.colorScheme.onPrimary
+                            color = gradientContentColor
                         )
                     }
                 },
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = Color.Transparent,
-                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    titleContentColor = MaterialTheme.colorScheme.onPrimary
+                    navigationIconContentColor = gradientContentColor,
+                    titleContentColor = gradientContentColor
                 )
             )
         },


### PR DESCRIPTION
## Summary
- replace the calendar loading indicator colors with MaterialTheme tones so light/dark themes stay legible
- switch calendar action cards and the activity map dialog to use surface/surfaceVariant colors instead of hardcoded white
- align the route preview card background with the themed surface color

## Testing
- ❌ `./gradlew lintDevDebug` (task not found; use lintDebug instead)
- ⚠️ `./gradlew lintDebug` (fails: Android SDK is not configured in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d12407746c8325ab78b2e40a4e1e83