### PR TITLE
Hide power curve for unsupported activities

### DIFF
--- a/app/src/main/java/com/example/fitnessapp/components/PerformanceChartsSection.kt
+++ b/app/src/main/java/com/example/fitnessapp/components/PerformanceChartsSection.kt
@@ -41,8 +41,9 @@ fun PerformanceChartsSection(
     // State for max BPM
     var maxBpm by remember { mutableStateOf<Float?>(null) }
 
-    // Fetch max BPM when component loads
-    LaunchedEffect(Unit) {
+    // Fetch max BPM when the activity changes
+    LaunchedEffect(activityId) {
+        maxBpm = null
         try {
             val maxBpmData = stravaViewModel.getMaxBpm()
             val maxBpmValue = maxBpmData["max_bpm"] as? Number

--- a/app/src/main/java/com/example/fitnessapp/components/PerformanceChartsSection.kt
+++ b/app/src/main/java/com/example/fitnessapp/components/PerformanceChartsSection.kt
@@ -80,6 +80,10 @@ fun PowerCurveSection(
     activity: StravaActivity?,
     modifier: Modifier = Modifier
 ) {
+    if (!isPowerCurveEligible(activityType)) {
+        return
+    }
+
     val context = LocalContext.current
     val stravaViewModel: StravaViewModel = viewModel(factory = StravaViewModelFactory(context))
 
@@ -87,7 +91,8 @@ fun PowerCurveSection(
     var maxBpm by remember { mutableStateOf<Int?>(null) }
 
     // Fetch max BPM when component loads
-    LaunchedEffect(Unit) {
+    LaunchedEffect(activityId) {
+        maxBpm = null
         try {
             val maxBpmData = stravaViewModel.getMaxBpm()
             val maxBpmValue = maxBpmData["max_bpm"] as? Number

--- a/app/src/main/java/com/example/fitnessapp/components/PowerCurveComponent.kt
+++ b/app/src/main/java/com/example/fitnessapp/components/PowerCurveComponent.kt
@@ -108,7 +108,7 @@ fun PowerCurveComponent(
     modifier: Modifier = Modifier,
     fthr: Int? = null
 ) {
-    if (activityType.lowercase() !in listOf("ride", "virtualride", "cycling")) return
+    if (!isPowerCurveEligible(activityType)) return
 
     val context = LocalContext.current
     val density = LocalDensity.current

--- a/app/src/main/java/com/example/fitnessapp/components/PowerCurveEligibility.kt
+++ b/app/src/main/java/com/example/fitnessapp/components/PowerCurveEligibility.kt
@@ -1,0 +1,14 @@
+package com.example.fitnessapp.components
+
+import java.util.Locale
+
+private val POWER_CURVE_ELIGIBLE_TYPES = setOf(
+    "ride",
+    "virtualride",
+    "cycling"
+)
+
+fun isPowerCurveEligible(activityType: String?): Boolean {
+    val normalizedType = activityType?.lowercase(Locale.getDefault()) ?: return false
+    return normalizedType in POWER_CURVE_ELIGIBLE_TYPES
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -88,8 +88,8 @@ import com.example.fitnessapp.R
 import com.example.fitnessapp.components.ActivityChartsComponent
 import com.example.fitnessapp.components.ActivityStatsSection
 import com.example.fitnessapp.components.PerformanceChartsSection
-import com.example.fitnessapp.components.PowerCurveComponent
 import com.example.fitnessapp.components.PowerCurveSection
+import com.example.fitnessapp.components.isPowerCurveEligible
 import com.example.fitnessapp.components.RouteMapSection
 import com.example.fitnessapp.ui.theme.FitnessAppTheme
 import com.example.fitnessapp.model.ActivityStreamsResponse
@@ -690,19 +690,22 @@ fun StravaActivityDetailScreen(
                                     }
                                 }
                             }
-                            // --- Section Header with Icon: Power Curve ---
-                            item {
-                                AnimatedVisibility(
-                                    visible = true,
-                                    enter = fadeIn(animationSpec = tween(300, delayMillis = 500)) + slideInVertically { it/4 }
-                                ) {
-                                    Column {
-                                        SectionHeader(Icons.Filled.Terrain, "Power Curve")
-                                        PowerCurveSection(
-                                            activityId = activityId,
-                                            activityType = activity!!.type,
-                                            activity = activity
-                                        )
+                            val showPowerCurve = isPowerCurveEligible(activity?.type)
+                            if (showPowerCurve) {
+                                // --- Section Header with Icon: Power Curve ---
+                                item {
+                                    AnimatedVisibility(
+                                        visible = true,
+                                        enter = fadeIn(animationSpec = tween(300, delayMillis = 500)) + slideInVertically { it/4 }
+                                    ) {
+                                        Column {
+                                            SectionHeader(Icons.Filled.Terrain, "Power Curve")
+                                            PowerCurveSection(
+                                                activityId = activityId,
+                                                activityType = activity!!.type,
+                                                activity = activity
+                                            )
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- add a shared helper to identify power-curve eligible activity types
- skip rendering the Power Curve section when the activity type is not supported and reset its data when the activity changes
- guard PowerCurveComponent with the same eligibility check

## Testing
- ⚠️ `./gradlew :app:lintDebug` *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13e44e13883259862fcd0ace3e048