### PR TITLE
Align metrics screens with theme

### DIFF
--- a/app/database/schema.sql
+++ b/app/database/schema.sql
@@ -1,0 +1,46 @@
+﻿
+-- Performance metrics tables
+CREATE TABLE IF NOT EXISTS metric_jobs (
+    job_id CHAR(36) PRIMARY KEY,
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    status ENUM('queued','running','done','error','cooldown') NOT NULL DEFAULT 'queued',
+    message TEXT NULL,
+    last_computed_at DATETIME NULL,
+    cooldown_until DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    INDEX idx_metric_jobs_user_metric (user_id, metric, created_at)
+);
+
+CREATE TABLE IF NOT EXISTS performance_metrics (
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    value VARCHAR(32) NULL,
+    unit VARCHAR(16) NULL,
+    last_computed_at DATETIME NULL,
+    window_days INT NULL,
+    source ENUM('strava','health_connect','manual') NULL,
+    status ENUM('ok','insufficient','cooldown','error') NOT NULL DEFAULT 'ok',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, metric),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS performance_metrics_history (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    value VARCHAR(32) NULL,
+    unit VARCHAR(16) NULL,
+    source ENUM('strava','health_connect','manual') NULL,
+    status ENUM('ok','insufficient','cooldown','error') NOT NULL,
+    window_days INT NULL,
+    last_computed_at DATETIME NULL,
+    recorded_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    INDEX idx_perf_history_user_metric (user_id, metric, recorded_at)
+);
+

--- a/app/src/main/java/com/example/fitnessapp/api/ApiService.kt
+++ b/app/src/main/java/com/example/fitnessapp/api/ApiService.kt
@@ -23,6 +23,8 @@ import com.example.fitnessapp.model.SetupStatusResponse
 import com.example.fitnessapp.model.SportsSelectionRequest
 import com.example.fitnessapp.model.SwimPacePredictions
 import com.example.fitnessapp.model.SwimmingPaceResponse
+import com.example.fitnessapp.model.PerformanceRecalcResponse
+import com.example.fitnessapp.model.PerformanceMetricStatusResponse
 import com.example.fitnessapp.model.TrainingDateUpdate
 import com.example.fitnessapp.model.TrainingPlan
 import com.example.fitnessapp.model.TrainingPlanCreateRequest
@@ -138,6 +140,19 @@ interface ApiService {
     suspend fun getSwimmingPace(
         @Header("Authorization") token: String
     ): Response<SwimmingPaceResponse>
+
+    @POST("metrics/recalc")
+    suspend fun recalc(
+        @Header("Authorization") token: String,
+        @Query("metric") metric: String
+    ): Response<PerformanceRecalcResponse>
+
+    @GET("metrics/status")
+    suspend fun getRecalcStatus(
+        @Header("Authorization") token: String,
+        @Query("metric") metric: String,
+        @Query("jobId") jobId: String
+    ): Response<PerformanceMetricStatusResponse>
 
     @GET("running/ftp")
     suspend fun getRunningFtp(

--- a/app/src/main/java/com/example/fitnessapp/model/PerformanceMetricStatusResponse.kt
+++ b/app/src/main/java/com/example/fitnessapp/model/PerformanceMetricStatusResponse.kt
@@ -1,0 +1,43 @@
+﻿package com.example.fitnessapp.model
+
+import com.google.gson.annotations.SerializedName
+
+data class PerformanceRecalcResponse(
+    @SerializedName("jobId")
+    val jobId: String? = null,
+    @SerializedName("job_id")
+    val jobIdSnake: String? = null,
+    @SerializedName("status")
+    val status: String? = null,
+    @SerializedName("message")
+    val message: String? = null
+) {
+    val resolvedJobId: String?
+        get() = jobId ?: jobIdSnake
+}
+
+data class PerformanceMetricStatusResponse(
+    @SerializedName("status")
+    val status: String? = null,
+    @SerializedName("lastComputedAt")
+    val lastComputedAt: String? = null,
+    @SerializedName("last_computed_at")
+    val lastComputedAtSnake: String? = null,
+    @SerializedName("message")
+    val message: String? = null,
+    @SerializedName("value")
+    val value: String? = null,
+    @SerializedName("unit")
+    val unit: String? = null,
+    @SerializedName("source")
+    val source: String? = null,
+    @SerializedName("cooldownUntil")
+    val cooldownUntil: String? = null,
+    @SerializedName("cooldown_until")
+    val cooldownUntilSnake: String? = null
+) {
+    val resolvedLastComputedAt: String?
+        get() = lastComputedAt ?: lastComputedAtSnake
+    val resolvedCooldownUntil: String?
+        get() = cooldownUntil ?: cooldownUntilSnake
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
@@ -3,6 +3,7 @@ package com.example.fitnessapp.pages.more
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -152,12 +151,8 @@ fun ChangeSportMetricsScreen(
             Surface(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(
-                        start = 16.dp,
-                        end = 16.dp,
-                        bottom = 16.dp,
-                        top = paddingValues.calculateTopPadding() + 16.dp
-                    ),
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
                 shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
                 color = MaterialTheme.extendedColors.surfaceSubtle,
                 tonalElevation = 2.dp

--- a/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
@@ -2,17 +2,21 @@ package com.example.fitnessapp.pages.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -22,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,8 +40,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -106,56 +107,68 @@ fun ChangeSportMetricsScreen(
 
     // TODO: Add state for loading, error, and success from viewmodel
 
-    val gradientColors = listOf(
-        MaterialTheme.extendedColors.gradientPrimary,
-        MaterialTheme.extendedColors.gradientSecondary,
-        MaterialTheme.extendedColors.gradientAccent
-    )
-
     Scaffold(
         containerColor = Color.Transparent,
         topBar = {
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(brush = Brush.verticalGradient(colors = gradientColors))
-                    .statusBarsPadding()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.extendedColors.gradientPrimary,
+                                MaterialTheme.extendedColors.gradientSecondary,
+                                MaterialTheme.extendedColors.gradientAccent
+                            )
+                        )
+                    )
                     .padding(horizontal = 16.dp, vertical = 20.dp)
             ) {
-                IconButton(
-                    onClick = { navController.navigateUp() },
-                    modifier = Modifier.align(Alignment.CenterStart)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                        tint = MaterialTheme.colorScheme.onPrimary
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Text(
+                        text = "Change Sport Metrics",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontWeight = FontWeight.Bold
                     )
                 }
-
-                Text(
-                    text = "Change Sport Metrics",
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.align(Alignment.Center)
-                )
             }
         }
     ) { paddingValues ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(brush = Brush.verticalGradient(colors = gradientColors))
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.extendedColors.gradientPrimary,
+                            MaterialTheme.extendedColors.gradientSecondary,
+                            MaterialTheme.extendedColors.gradientAccent
+                        )
+                    )
+                )
         ) {
-            Surface(
+            Card(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(horizontal = 16.dp, vertical = 16.dp),
-                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-                color = MaterialTheme.extendedColors.surfaceSubtle,
-                tonalElevation = 2.dp
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
+                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -322,7 +335,7 @@ fun ChangeSportMetricsScreen(
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 contentColor = MaterialTheme.colorScheme.onPrimary
                             ),
-                            shape = RoundedCornerShape(16.dp)
+                            shape = RoundedCornerShape(12.dp)
                         ) {
                             Text(
                                 text = "Save Changes",

--- a/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/ChangeSportMetricsScreen.kt
@@ -2,9 +2,9 @@ package com.example.fitnessapp.pages.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,10 +20,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import com.example.fitnessapp.ui.theme.extendedColors
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,6 +38,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -52,6 +54,7 @@ import com.example.fitnessapp.pages.signup.SwimPaceData
 import com.example.fitnessapp.pages.signup.SwimPaceEntryCard
 import com.example.fitnessapp.viewmodel.AuthViewModel
 import com.example.fitnessapp.viewmodel.SetupViewModel
+import com.example.fitnessapp.ui.theme.extendedColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -104,25 +107,26 @@ fun ChangeSportMetricsScreen(
 
     // TODO: Add state for loading, error, and success from viewmodel
 
+    val gradientColors = listOf(
+        MaterialTheme.extendedColors.gradientPrimary,
+        MaterialTheme.extendedColors.gradientSecondary,
+        MaterialTheme.extendedColors.gradientAccent
+    )
+
     Scaffold(
+        containerColor = Color.Transparent,
         topBar = {
-            Row(
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primary,
-                                MaterialTheme.extendedColors.chartAltitude,
-                                MaterialTheme.extendedColors.gradientAccent
-                            )
-                        )
-                    )
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                    .background(brush = Brush.verticalGradient(colors = gradientColors))
+                    .statusBarsPadding()
+                    .padding(horizontal = 16.dp, vertical = 20.dp)
             ) {
-                IconButton(onClick = { navController.navigateUp() }) {
+                IconButton(
+                    onClick = { navController.navigateUp() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
@@ -134,180 +138,205 @@ fun ChangeSportMetricsScreen(
                     text = "Change Sport Metrics",
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center)
                 )
-
-                Spacer(modifier = Modifier.weight(1f))
             }
         }
     ) { paddingValues ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .background(brush = Brush.verticalGradient(colors = gradientColors))
         ) {
-            // Cycling FTP Section
-            item {
-                ModernSection(title = "Cycling FTP") {
-                    OutlinedTextField(
-                        value = ftpValue,
-                        onValueChange = { ftpValue = it },
-                        label = { Text("FTP Value (watts)") },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = MaterialTheme.colorScheme.primary,
-                            unfocusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                        )
-                    )
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            // Running Max BPM Section
-            item {
-                ModernSection(title = "Running Max BPM") {
-                    OutlinedTextField(
-                        value = maxBpmValue,
-                        onValueChange = { maxBpmValue = it },
-                        label = { Text("Max BPM (beats per minute)") },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = MaterialTheme.colorScheme.primary,
-                            unfocusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                        )
-                    )
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            // Running Paces Section
-            item {
-                ModernSection(title = "Running Paces") {
-                    Column(
-                        modifier = Modifier.padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        runningEntries.forEachIndexed { index, entry ->
-                            RunningPaceEntryCard(
-                                entry = entry,
-                                onEntryChange = { newEntry ->
-                                    runningEntries = runningEntries.toMutableList().apply {
-                                        set(index, newEntry)
-                                    }
-                                }
-                            )
-                        }
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            // Swimming Paces Section
-            item {
-                ModernSection(title = "Swimming Paces") {
-                    Column(
-                        modifier = Modifier.padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        swimEntries.forEachIndexed { index, entry ->
-                            SwimPaceEntryCard(
-                                entry = entry,
-                                onEntryChange = { newEntry ->
-                                    swimEntries = swimEntries.toMutableList().apply {
-                                        set(index, newEntry)
-                                    }
-                                }
-                            )
-                        }
-                    }
-                }
-                Spacer(modifier = Modifier.height(32.dp))
-            }
-
-            // Submit Button
-            item {
-                Button(
-                    onClick = {
-                        val token = authViewModel.getToken()
-                        if (token != null) {
-                            // FTP
-                            val ftpInt = ftpValue.toIntOrNull()
-                            if (ftpInt != null && ftpInt > 0) {
-                                setupViewModel.submitCyclingData(token, ftpInt)
-                            }
-
-                            // Max BPM
-                            val maxBpmInt = maxBpmValue.toIntOrNull()
-                            if (maxBpmInt != null && maxBpmInt > 0) {
-                                // TODO: Add setupViewModel method for Max BPM
-                                // setupViewModel.submitMaxBpm(token, maxBpmInt)
-                            }
-
-                            // Running
-                            val validRunningEntries = runningEntries.mapNotNull { entry ->
-                                val minutes = entry.minutes.toIntOrNull()
-                                val seconds = entry.seconds.toIntOrNull()
-                                if (minutes != null && seconds != null && (minutes > 0 || seconds > 0)) {
-                                    val timeString = String.format("%d:%02d", minutes, seconds)
-                                    RunningPrediction(
-                                        distanceKm = entry.distance.distanceKm,
-                                        time = timeString
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = 16.dp,
+                        end = 16.dp,
+                        bottom = 16.dp,
+                        top = paddingValues.calculateTopPadding() + 16.dp
+                    ),
+                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                color = MaterialTheme.extendedColors.surfaceSubtle,
+                tonalElevation = 2.dp
+            ) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                ) {
+                    // Cycling FTP Section
+                    item {
+                        ModernSection(title = "Cycling FTP") {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                OutlinedTextField(
+                                    value = ftpValue,
+                                    onValueChange = { ftpValue = it },
+                                    label = { Text("FTP Value (watts)") },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    shape = RoundedCornerShape(12.dp),
+                                    colors = OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                        unfocusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                                     )
-                                } else null
-                            }
-                            if (validRunningEntries.isNotEmpty()) {
-                                setupViewModel.submitRunningPacePredictions(
-                                    token,
-                                    validRunningEntries
                                 )
                             }
+                        }
+                    }
 
-                            // Swimming
-                            val validSwimEntries = swimEntries.mapNotNull { entry ->
-                                val minutes = entry.minutes.toIntOrNull()
-                                val seconds = entry.seconds.toIntOrNull()
-                                if (minutes != null && seconds != null && (minutes > 0 || seconds > 0)) {
-                                    val timeString = String.format("%d:%02d", minutes, seconds)
-                                    SwimPrediction(
-                                        distanceM = entry.distance.distanceMeters,
-                                        time = timeString
+                    // Running Max BPM Section
+                    item {
+                        ModernSection(title = "Running Max BPM") {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                OutlinedTextField(
+                                    value = maxBpmValue,
+                                    onValueChange = { maxBpmValue = it },
+                                    label = { Text("Max BPM (beats per minute)") },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    shape = RoundedCornerShape(12.dp),
+                                    colors = OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                        unfocusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                                     )
-                                } else null
-                            }
-                            if (validSwimEntries.isNotEmpty()) {
-                                setupViewModel.submitSwimPacePredictions(token, validSwimEntries)
+                                )
                             }
                         }
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .padding(horizontal = 16.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    ),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Text(
-                        text = "Save Changes",
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium
-                    )
+                    }
+
+                    // Running Paces Section
+                    item {
+                        ModernSection(title = "Running Paces") {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                runningEntries.forEachIndexed { index, entry ->
+                                    RunningPaceEntryCard(
+                                        entry = entry,
+                                        onEntryChange = { newEntry ->
+                                            runningEntries = runningEntries.toMutableList().apply {
+                                                set(index, newEntry)
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // Swimming Paces Section
+                    item {
+                        ModernSection(title = "Swimming Paces") {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                swimEntries.forEachIndexed { index, entry ->
+                                    SwimPaceEntryCard(
+                                        entry = entry,
+                                        onEntryChange = { newEntry ->
+                                            swimEntries = swimEntries.toMutableList().apply {
+                                                set(index, newEntry)
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // Submit Button
+                    item {
+                        Button(
+                            onClick = {
+                                val token = authViewModel.getToken()
+                                if (token != null) {
+                                    // FTP
+                                    val ftpInt = ftpValue.toIntOrNull()
+                                    if (ftpInt != null && ftpInt > 0) {
+                                        setupViewModel.submitCyclingData(token, ftpInt)
+                                    }
+
+                                    // Max BPM
+                                    val maxBpmInt = maxBpmValue.toIntOrNull()
+                                    if (maxBpmInt != null && maxBpmInt > 0) {
+                                        // TODO: Add setupViewModel method for Max BPM
+                                        // setupViewModel.submitMaxBpm(token, maxBpmInt)
+                                    }
+
+                                    // Running
+                                    val validRunningEntries = runningEntries.mapNotNull { entry ->
+                                        val minutes = entry.minutes.toIntOrNull()
+                                        val seconds = entry.seconds.toIntOrNull()
+                                        if (minutes != null && seconds != null && (minutes > 0 || seconds > 0)) {
+                                            val timeString = String.format("%d:%02d", minutes, seconds)
+                                            RunningPrediction(
+                                                distanceKm = entry.distance.distanceKm,
+                                                time = timeString
+                                            )
+                                        } else null
+                                    }
+                                    if (validRunningEntries.isNotEmpty()) {
+                                        setupViewModel.submitRunningPacePredictions(
+                                            token,
+                                            validRunningEntries
+                                        )
+                                    }
+
+                                    // Swimming
+                                    val validSwimEntries = swimEntries.mapNotNull { entry ->
+                                        val minutes = entry.minutes.toIntOrNull()
+                                        val seconds = entry.seconds.toIntOrNull()
+                                        if (minutes != null && seconds != null && (minutes > 0 || seconds > 0)) {
+                                            val timeString = String.format("%d:%02d", minutes, seconds)
+                                            SwimPrediction(
+                                                distanceM = entry.distance.distanceMeters,
+                                                time = timeString
+                                            )
+                                        } else null
+                                    }
+                                    if (validSwimEntries.isNotEmpty()) {
+                                        setupViewModel.submitSwimPacePredictions(token, validSwimEntries)
+                                    }
+                                }
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(56.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary
+                            ),
+                            shape = RoundedCornerShape(16.dp)
+                        ) {
+                            Text(
+                                text = "Save Changes",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                    }
                 }
-                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }

--- a/app/src/main/java/com/example/fitnessapp/pages/more/ContactUsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/ContactUsScreen.kt
@@ -1,0 +1,214 @@
+package com.example.fitnessapp.pages.more
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.SupportAgent
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.fitnessapp.mock.SharedPreferencesMock
+import com.example.fitnessapp.viewmodel.AuthViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactUsScreen(
+    navController: NavController,
+    authViewModel: AuthViewModel
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            ContactTopBar(onBack = { navController.navigateUp() })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            ContactCard(
+                icon = androidx.compose.material.icons.Icons.Filled.Email,
+                title = "Email support",
+                description = "We aim to reply within one business day."
+            ) {
+                OutlinedButton(onClick = {
+                    openEmail(context, "support@fitsense.app", "Question about FitSense")
+                }) {
+                    Text("Compose email")
+                }
+            }
+
+            ContactCard(
+                icon = androidx.compose.material.icons.Icons.Filled.SupportAgent,
+                title = "Live chat",
+                description = "Chat with our coaches between 7am and 8pm GMT."
+            ) {
+                Text(
+                    text = "Open the chat widget from the web dashboard for detailed conversation logs.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            ContactCard(
+                icon = androidx.compose.material.icons.Icons.Filled.Forum,
+                title = "Community forum",
+                description = "Share tips and discover training plans from other athletes."
+            ) {
+                OutlinedButton(onClick = {
+                    openLink(context, "https://community.fitsense.app")
+                }) {
+                    Text("Visit forum")
+                }
+            }
+
+            ContactCard(
+                icon = androidx.compose.material.icons.Icons.Filled.Language,
+                title = "Status page",
+                description = "Check service availability and planned maintenance."
+            ) {
+                OutlinedButton(onClick = {
+                    openLink(context, "https://status.fitsense.app")
+                }) {
+                    Text("View status")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun ContactTopBar(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+                    )
+                )
+            )
+            .padding(horizontal = 16.dp, vertical = 18.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Text(
+            text = "Contact us",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Spacer(modifier = Modifier.height(0.dp))
+    }
+}
+
+@Composable
+private fun ContactCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    description: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            content()
+        }
+    }
+}
+
+private fun openEmail(context: android.content.Context, address: String, subject: String) {
+    val intent = Intent(Intent.ACTION_SENDTO).apply {
+        data = Uri.parse("mailto:")
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(address))
+        putExtra(Intent.EXTRA_SUBJECT, subject)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, "No email client installed", Toast.LENGTH_SHORT).show()
+    }
+}
+
+private fun openLink(context: android.content.Context, url: String) {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+    try {
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, "Unable to open link", Toast.LENGTH_SHORT).show()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ContactUsScreenPreview() {
+    ContactUsScreen(
+        navController = rememberNavController(),
+        authViewModel = AuthViewModel(SharedPreferencesMock())
+    )
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/HelpSupportScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/HelpSupportScreen.kt
@@ -1,0 +1,227 @@
+package com.example.fitnessapp.pages.more
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Help
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Update
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.fitnessapp.mock.SharedPreferencesMock
+import com.example.fitnessapp.viewmodel.AuthViewModel
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HelpSupportScreen(
+    navController: NavController,
+    authViewModel: AuthViewModel
+) {
+    Scaffold(
+        topBar = {
+            HelpTopBar(onBack = { navController.navigateUp() })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            ReleaseNotesCard()
+            DiagnosticsCard()
+            FaqSection()
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun HelpTopBar(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+                    )
+                )
+            )
+            .padding(horizontal = 16.dp, vertical = 18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Text(
+            text = "Help & support",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Spacer(modifier = Modifier.height(0.dp))
+    }
+}
+
+@Composable
+private fun ReleaseNotesCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(imageVector = androidx.compose.material.icons.Icons.Filled.Update, contentDescription = null)
+                Text("What's new", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            Text(
+                text = "Stay up to date with the latest FitSense features and improvements.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedButton(onClick = { /* TODO open changelog */ }) {
+                Text("View release notes")
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiagnosticsCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(imageVector = androidx.compose.material.icons.Icons.Filled.Info, contentDescription = null)
+                Text("Diagnostics", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            Text(
+                text = "Generate a report containing app logs and recent sync status to share with support.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedButton(onClick = { /* TODO export diagnostics */ }) {
+                Text("Export diagnostics")
+            }
+        }
+    }
+}
+
+@Composable
+private fun FaqSection() {
+    val faqs = remember {
+        listOf(
+            "How do I sync workouts from my trainer?" to "Connect your account under App Integrations to automatically import workouts from Strava or Health Connect.",
+            "Can I edit a training plan after it's created?" to "Yes. Open the plan from the calendar and adjust individual sessions or regenerate using quick plan.",
+            "How is Training Stress Score calculated?" to "We combine power, heart-rate and session length to calculate TSS using your sport-specific thresholds.",
+            "Why don't I see Health Connect data?" to "Ensure permissions are granted and perform a manual sync from the Integrations screen."
+        )
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(imageVector = androidx.compose.material.icons.Icons.Filled.Help, contentDescription = null)
+                Text("Frequently asked questions", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            faqs.forEach { (question, answer) ->
+                ExpandableFaq(question = question, answer = answer)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpandableFaq(question: String, answer: String) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = if (expanded) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .clickable { expanded = !expanded }
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(question, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+        AnimatedVisibility(visible = expanded) {
+            Text(
+                text = answer,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HelpSupportScreenPreview() {
+    HelpSupportScreen(
+        navController = rememberNavController(),
+        authViewModel = AuthViewModel(SharedPreferencesMock())
+    )
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/MyAccountScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/MyAccountScreen.kt
@@ -1,0 +1,276 @@
+package com.example.fitnessapp.pages.more
+
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.fitnessapp.R
+import com.example.fitnessapp.mock.SharedPreferencesMock
+import com.example.fitnessapp.navigation.Routes
+import com.example.fitnessapp.viewmodel.AuthViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyAccountScreen(
+    navController: NavController,
+    authViewModel: AuthViewModel
+) {
+    val context = LocalContext.current
+    val userData by authViewModel.userTrainingData.observeAsState()
+
+    LaunchedEffect(Unit) {
+        if (authViewModel.userTrainingData.value == null) {
+            authViewModel.getUserTrainingData()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            AccountTopBar(
+                title = "My Account",
+                onBack = { navController.navigateUp() }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            ProfileCard(userData)
+
+            AccountSection(
+                title = "Security",
+                description = "Manage how you sign in and keep your account protected."
+            ) {
+                OutlinedButton(onClick = { toast(context, "Change password coming soon") }) {
+                    Text("Change password")
+                }
+                OutlinedButton(onClick = { toast(context, "Change email coming soon") }) {
+                    Text("Update email")
+                }
+            }
+
+            AccountSection(
+                title = "Preferences",
+                description = "Keep your training data and connected apps in sync."
+            ) {
+                Button(onClick = { navController.navigate(Routes.CHANGE_SPORT_METRICS) }) {
+                    Text("Adjust sport metrics")
+                }
+                OutlinedButton(onClick = { navController.navigate(Routes.APP_INTEGRATIONS) }) {
+                    Text("Manage integrations")
+                }
+            }
+
+            DangerZone { toast(context, "Account deletion flow coming soon") }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun AccountTopBar(
+    title: String,
+    onBack: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+                    )
+                )
+            )
+            .padding(horizontal = 16.dp, vertical = 18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Spacer(modifier = Modifier.size(48.dp))
+    }
+}
+
+@Composable
+private fun ProfileCard(userData: com.example.fitnessapp.model.UserTrainigData?) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.iclogo),
+                contentDescription = "Profile image",
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(CircleShape)
+            )
+            Text(
+                text = "Athlete profile",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Divider(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Cycling FTP", style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        text = userData?.ftp?.takeIf { it > 0 }?.let { "$it W" } ?: "Not set",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Max BPM", style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        text = userData?.max_bpm?.takeIf { it > 0 }?.let { "$it bpm" } ?: "Not set",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountSection(
+    title: String,
+    description: String,
+    content: @Composable () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun DangerZone(onDelete: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Danger zone",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Text(
+                text = "Deleting your account removes all synced workouts and preferences.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Button(
+                onClick = onDelete,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError
+                )
+            ) {
+                Text("Delete account")
+            }
+        }
+    }
+}
+
+private fun toast(context: android.content.Context, message: String) {
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyAccountScreenPreview() {
+    MyAccountScreen(
+        navController = rememberNavController(),
+        authViewModel = AuthViewModel(SharedPreferencesMock())
+    )
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/PerformanceScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/PerformanceScreen.kt
@@ -1,0 +1,380 @@
+﻿package com.example.fitnessapp.pages.more
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Pool
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.fitnessapp.navigation.Routes
+import com.example.fitnessapp.viewmodel.AuthViewModel
+import com.example.fitnessapp.viewmodel.MetricCardState
+import com.example.fitnessapp.viewmodel.MetricStatus
+import com.example.fitnessapp.viewmodel.MetricType
+import com.example.fitnessapp.viewmodel.PerformanceViewModel
+
+@Composable
+fun PerformanceScreen(
+    navController: NavController,
+    authViewModel: AuthViewModel,
+    performanceViewModel: PerformanceViewModel = viewModel()
+) {
+    val uiState by performanceViewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var metricToRecalculate by remember { mutableStateOf<MetricType?>(null) }
+
+    LaunchedEffect(Unit) {
+        performanceViewModel.refreshAll(authViewModel.getToken())
+    }
+
+    LaunchedEffect(uiState.globalError) {
+        uiState.globalError?.let { message ->
+            if (message.isNotBlank()) {
+                snackbarHostState.showSnackbar(message)
+            }
+        }
+    }
+
+    metricToRecalculate?.let { metric ->
+        AlertDialog(
+            onDismissRequest = { metricToRecalculate = null },
+            title = { Text(text = "Confirm\u0103 recalcularea") },
+            text = {
+                Text(
+                    text = "Pornim recalcularea pentru ${metric.displayName}? Aceasta poate dura c\u00E2teva minute."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        performanceViewModel.recalc(metric, authViewModel.getToken())
+                        metricToRecalculate = null
+                    }
+                ) {
+                    Text(text = "Recalculeaz\u0103")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { metricToRecalculate = null }) {
+                    Text(text = "Renun\u021B\u0103")
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = "Performance") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "\u00CEnapoi"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { performanceViewModel.refreshAll(authViewModel.getToken()) }) {
+                        Icon(
+                            imageVector = Icons.Filled.Refresh,
+                            contentDescription = "Re\u00EEmprosp\u0103teaz\u0103"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary,
+                            MaterialTheme.colorScheme.surface
+                        )
+                    )
+                )
+                .padding(paddingValues)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                if (uiState.isLoading) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(MetricType.values(), key = { it.name }) { type ->
+                        val metricState = uiState.metrics[type] ?: MetricCardState(type)
+                        PerformanceMetricCard(
+                            state = metricState,
+                            onRefresh = { performanceViewModel.refreshMetric(type, authViewModel.getToken()) },
+                            onRecalculate = { metricToRecalculate = type }
+                        )
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Box(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            TextButton(onClick = { navController.navigate(Routes.CHANGE_SPORT_METRICS) }) {
+                                Text(text = "Actualizeaz\u0103 manual metricile")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PerformanceMetricCard(
+    state: MetricCardState,
+    onRefresh: () -> Unit,
+    onRecalculate: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            MetricHeader(state = state)
+
+            AnimatedVisibility(visible = state.isRefreshing || state.isRecalculating) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            MetricValueRow(state = state)
+
+            Divider(color = MaterialTheme.colorScheme.surfaceVariant)
+
+            MetricMetaRow(state = state)
+
+            state.statusMessage?.takeIf { it.isNotBlank() }?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            state.error?.takeIf { it.isNotBlank() }?.let { error ->
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(
+                    onClick = onRefresh,
+                    enabled = !state.isRefreshing && !state.isRecalculating
+                ) {
+                    Text(text = "Actualizeaz\u0103")
+                }
+
+                Button(
+                    onClick = onRecalculate,
+                    enabled = !state.isRecalculating && state.status != MetricStatus.COOLDOWN,
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                ) {
+                    if (state.isRecalculating) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .size(18.dp),
+                            strokeWidth = 2.dp
+                        )
+                    }
+                    Text(text = "Recalculeaz\u0103")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricHeader(state: MetricCardState) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = metricIcon(state.metric),
+                contentDescription = state.label,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Column {
+                Text(
+                    text = state.label,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = state.unit,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        StatusBadge(status = state.status)
+    }
+}
+
+@Composable
+private fun MetricValueRow(state: MetricCardState) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = state.value ?: "--",
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = state.status.displayText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun MetricMetaRow(state: MetricCardState) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        MetaLine(label = "Ultima actualizare", value = state.lastUpdated ?: "--")
+        MetaLine(label = "Surs\u0103", value = state.source ?: "--")
+        if (!state.cooldownUntil.isNullOrBlank()) {
+            MetaLine(label = "Cooldown", value = state.cooldownUntil)
+        }
+    }
+}
+
+@Composable
+private fun MetaLine(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun StatusBadge(status: MetricStatus) {
+    val (background, content) = when (status) {
+        MetricStatus.OK -> MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+        MetricStatus.RECALCULATING -> MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        MetricStatus.COOLDOWN -> MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+        MetricStatus.INSUFFICIENT -> MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+        MetricStatus.ERROR -> MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+        MetricStatus.UNKNOWN -> MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Box(
+        modifier = Modifier
+            .background(background, RoundedCornerShape(12.dp))
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            text = status.displayText,
+            style = MaterialTheme.typography.labelMedium,
+            color = content
+        )
+    }
+}
+
+@Composable
+private fun metricIcon(metric: MetricType) = when (metric) {
+    MetricType.CYCLING_FTP -> Icons.Filled.DirectionsBike
+    MetricType.RUNNING_FTP -> Icons.Filled.DirectionsRun
+    MetricType.SWIM_CSS -> Icons.Filled.Pool
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/SettingsScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/SettingsScreen.kt
@@ -1,0 +1,253 @@
+package com.example.fitnessapp.pages.more
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.fitnessapp.mock.SharedPreferencesMock
+import com.example.fitnessapp.viewmodel.AuthViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    navController: NavController,
+    authViewModel: AuthViewModel
+) {
+    LaunchedEffect(Unit) {
+        authViewModel.userTrainingData
+    }
+
+    Scaffold(
+        topBar = {
+            SettingsTopBar(onBack = { navController.navigateUp() })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            UnitsSection()
+            ThemeSection()
+            NotificationSection()
+            PrivacySection()
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingsTopBar(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+                    )
+                )
+            )
+            .padding(horizontal = 16.dp, vertical = 18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Text(
+            text = "App settings",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Spacer(modifier = Modifier.height(0.dp))
+    }
+}
+
+@Composable
+private fun SettingsCard(
+    title: String,
+    description: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            content()
+        }
+    }
+}
+
+@Composable
+private fun UnitsSection() {
+    var useMetric by rememberSaveable { mutableStateOf(true) }
+    SettingsCard(
+        title = "Units",
+        description = "Choose how distances and temperatures are displayed throughout the app."
+    ) {
+        SettingsToggleRow(
+            title = "Metric units",
+            subtitle = "Kilometres, metres, Celsius",
+            checked = useMetric,
+            onToggle = { useMetric = it }
+        )
+        SettingsToggleRow(
+            title = "Imperial units",
+            subtitle = "Miles, feet, Fahrenheit",
+            checked = !useMetric,
+            onToggle = { useMetric = !useMetric }
+        )
+    }
+}
+
+@Composable
+private fun ThemeSection() {
+    var darkMode by rememberSaveable { mutableStateOf(false) }
+    SettingsCard(
+        title = "Appearance",
+        description = "Switch between light and dark theme to match your environment."
+    ) {
+        SettingsToggleRow(
+            title = "Use dark theme",
+            subtitle = "Automatically adjusts colours for low light",
+            checked = darkMode,
+            onToggle = { darkMode = it }
+        )
+    }
+}
+
+@Composable
+private fun NotificationSection() {
+    var sessionReminders by rememberSaveable { mutableStateOf(true) }
+    var summaryEmail by rememberSaveable { mutableStateOf(false) }
+    SettingsCard(
+        title = "Notifications",
+        description = "Control which reminders and digests you receive."
+    ) {
+        SettingsToggleRow(
+            title = "Session reminders",
+            subtitle = "Push notification 30 minutes before a workout",
+            checked = sessionReminders,
+            onToggle = { sessionReminders = it }
+        )
+        SettingsToggleRow(
+            title = "Weekly email summary",
+            subtitle = "A recap of your training every Monday",
+            checked = summaryEmail,
+            onToggle = { summaryEmail = it }
+        )
+    }
+}
+
+@Composable
+private fun PrivacySection() {
+    var shareAnalytics by rememberSaveable { mutableStateOf(true) }
+    var downloadData by rememberSaveable { mutableStateOf(false) }
+    SettingsCard(
+        title = "Privacy & data",
+        description = "Manage how your data is stored and shared."
+    ) {
+        SettingsToggleRow(
+            title = "Share anonymised analytics",
+            subtitle = "Help us improve training recommendations",
+            checked = shareAnalytics,
+            onToggle = { shareAnalytics = it }
+        )
+        SettingsToggleRow(
+            title = "Automatically export workout files",
+            subtitle = "Sync new workouts to your cloud storage",
+            checked = downloadData,
+            onToggle = { downloadData = it }
+        )
+    }
+}
+
+@Composable
+private fun SettingsToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onToggle)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenPreview() {
+    SettingsScreen(
+        navController = rememberNavController(),
+        authViewModel = AuthViewModel(SharedPreferencesMock())
+    )
+}

--- a/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -109,12 +108,8 @@ fun TrainingZonesScreen(
             Surface(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(
-                        start = 16.dp,
-                        end = 16.dp,
-                        bottom = 16.dp,
-                        top = paddingValues.calculateTopPadding() + 16.dp
-                    ),
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
                 shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
                 color = MaterialTheme.extendedColors.surfaceSubtle,
                 tonalElevation = 2.dp

--- a/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
@@ -2,21 +2,22 @@ package com.example.fitnessapp.pages.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DirectionsBike
@@ -29,8 +30,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import com.example.fitnessapp.ui.theme.extendedColors
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.fitnessapp.mock.SharedPreferencesMock
+import com.example.fitnessapp.ui.theme.extendedColors
 import com.example.fitnessapp.viewmodel.AuthViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -62,25 +64,26 @@ fun TrainingZonesScreen(
     var currentHeartRate by remember { mutableStateOf(150) } // Current HR for demo
     var currentPower by remember { mutableStateOf(200) } // Current power for demo
 
+    val gradientColors = listOf(
+        MaterialTheme.extendedColors.gradientPrimary,
+        MaterialTheme.extendedColors.gradientSecondary,
+        MaterialTheme.extendedColors.gradientAccent
+    )
+
     Scaffold(
+        containerColor = Color.Transparent,
         topBar = {
-            Row(
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primary,
-                                MaterialTheme.extendedColors.chartAltitude,
-                                MaterialTheme.extendedColors.gradientAccent
-                            )
-                        )
-                    )
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                    .background(brush = Brush.verticalGradient(colors = gradientColors))
+                    .statusBarsPadding()
+                    .padding(horizontal = 16.dp, vertical = 20.dp)
             ) {
-                IconButton(onClick = { navController.navigateUp() }) {
+                IconButton(
+                    onClick = { navController.navigateUp() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
@@ -92,52 +95,86 @@ fun TrainingZonesScreen(
                     text = "Training Zones",
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center)
                 )
-
-                Spacer(modifier = Modifier.weight(1f))
             }
         }
     ) { paddingValues ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp),
-            contentPadding = PaddingValues(
-                top = 8.dp + WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-            ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .background(brush = Brush.verticalGradient(colors = gradientColors))
         ) {
-            // Current Status Section
-            item {
-                CurrentStatusSection(
-                    currentPower = currentPower,
-                    currentHeartRate = currentHeartRate,
-                    userFtp = userFtp,
-                    userMaxBpm = userMaxBpm
-                )
-            }
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = 16.dp,
+                        end = 16.dp,
+                        bottom = 16.dp,
+                        top = paddingValues.calculateTopPadding() + 16.dp
+                    ),
+                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                color = MaterialTheme.extendedColors.surfaceSubtle,
+                tonalElevation = 2.dp
+            ) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                ) {
+                    item {
+                        CurrentStatusSection(
+                            currentPower = currentPower,
+                            currentHeartRate = currentHeartRate,
+                            userFtp = userFtp,
+                            userMaxBpm = userMaxBpm
+                        )
+                    }
 
-            // Cycling Zones Section
-            item {
-                CyclingZonesSection(userFtp = userFtp)
-            }
+                    item {
+                        CyclingZonesSection(userFtp)
+                    }
 
-            // Running Zones Section
-            item {
-                RunningZonesSection(userMaxBpm = userMaxBpm)
-            }
+                    item {
+                        RunningZonesSection(userMaxBpm)
+                    }
 
-            // Swimming Zones Section
-            item {
-                SwimmingZonesSection()
-            }
+                    item {
+                        SwimmingZonesSection()
+                    }
 
-            // Bottom spacing
-            item {
-                Spacer(modifier = Modifier.height(32.dp))
+                    item {
+                        TrainingSection(title = "Training Tips") {
+                            Column(
+                                modifier = Modifier.padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                TrainingTip(
+                                    icon = Icons.Default.FitnessCenter,
+                                    title = "Balance your Training",
+                                    description = "Include recovery days and easy sessions to avoid overtraining."
+                                )
+                                TrainingTip(
+                                    icon = Icons.Default.DirectionsBike,
+                                    title = "Mix Intensities",
+                                    description = "Combine different zones in your weekly plan for optimal progress."
+                                )
+                                TrainingTip(
+                                    icon = Icons.Default.DirectionsRun,
+                                    title = "Monitor Heart Rate",
+                                    description = "Track your HR zones to ensure you're hitting the right effort."
+                                )
+                                TrainingTip(
+                                    icon = Icons.Default.Pool,
+                                    title = "Technique Matters",
+                                    description = "Focus on form, especially in high-intensity sessions."
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -155,14 +192,15 @@ fun CurrentStatusSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             CurrentMetricCard(
                 title = "Power Zone",
                 value = calculatePowerZone(currentPower.toDouble(), userFtp.toDouble()),
                 subtitle = "$currentPower W",
                 icon = Icons.Default.DirectionsBike,
-                color = getPowerZoneColor(currentPower.toDouble(), userFtp.toDouble())
+                color = getPowerZoneColor(currentPower.toDouble(), userFtp.toDouble()),
+                modifier = Modifier.weight(1f)
             )
 
             CurrentMetricCard(
@@ -170,7 +208,8 @@ fun CurrentStatusSection(
                 value = calculateHeartRateZone(currentHeartRate, userMaxBpm),
                 subtitle = "$currentHeartRate BPM",
                 icon = Icons.Default.DirectionsRun,
-                color = getHeartRateZoneColor(currentHeartRate, userMaxBpm)
+                color = getHeartRateZoneColor(currentHeartRate, userMaxBpm),
+                modifier = Modifier.weight(1f)
             )
         }
     }
@@ -182,27 +221,27 @@ fun CurrentMetricCard(
     value: String,
     subtitle: String,
     icon: ImageVector,
-    color: Color
+    color: Color,
+    modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = Modifier.size(width = 160.dp, height = 120.dp),
-        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.1f)),
-        shape = RoundedCornerShape(12.dp)
+        modifier = modifier.height(136.dp),
+        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.12f)),
+        shape = RoundedCornerShape(16.dp)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(12.dp),
+                .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = title,
                 tint = color,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(28.dp)
             )
-            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = title,
                 style = MaterialTheme.typography.bodySmall,
@@ -210,7 +249,7 @@ fun CurrentMetricCard(
             )
             Text(
                 text = value,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = color
             )
@@ -228,7 +267,7 @@ fun CyclingZonesSection(userFtp: Int) {
     TrainingSection(title = "Cycling Power Zones (FTP: ${userFtp}W)") {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             val zones = listOf(
                 ZoneInfo("Zone 1", "Recovery", "< 56%", "< ${(userFtp * 0.56).toInt()}W", MaterialTheme.extendedColors.success),
@@ -252,7 +291,7 @@ fun RunningZonesSection(userMaxBpm: Int) {
     TrainingSection(title = "Running Heart Rate Zones (Max: ${userMaxBpm} BPM)") {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             val zones = listOf(
                 ZoneInfo("Zone 1", "Recovery", "< 60%", "< ${(userMaxBpm * 0.60).toInt()} BPM", MaterialTheme.extendedColors.success),
@@ -274,7 +313,7 @@ fun SwimmingZonesSection() {
     TrainingSection(title = "Swimming Training Zones") {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             val zones = listOf(
                 ZoneInfo("EN1", "Aerobic Base", "Easy", "Conversational pace", MaterialTheme.extendedColors.success),
@@ -296,7 +335,7 @@ fun ZoneCard(zone: ZoneInfo, icon: ImageVector) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = zone.color.copy(alpha = 0.1f)),
-        shape = RoundedCornerShape(8.dp)
+        shape = RoundedCornerShape(12.dp)
     ) {
         Row(
             modifier = Modifier
@@ -310,8 +349,11 @@ fun ZoneCard(zone: ZoneInfo, icon: ImageVector) {
                 tint = zone.color,
                 modifier = Modifier.size(20.dp)
             )
-            Spacer(modifier = Modifier.padding(8.dp))
-            Column(modifier = Modifier.weight(1f)) {
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 Text(
                     text = "${zone.zone} - ${zone.name}",
                     style = MaterialTheme.typography.bodyMedium,
@@ -405,11 +447,40 @@ fun TrainingSection(title: String, content: @Composable ColumnScope.() -> Unit) 
         )
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.extendedColors.surfaceSubtle),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            Column(modifier = Modifier.padding(8.dp), content = content)
+            Column(modifier = Modifier.padding(16.dp), content = content)
+        }
+    }
+}
+
+@Composable
+fun TrainingTip(icon: ImageVector, title: String, description: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }
@@ -422,5 +493,3 @@ fun TrainingZonesScreenPreview() {
         authViewModel = AuthViewModel(SharedPreferencesMock())
     )
 }
-
-

--- a/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/TrainingZonesScreen.kt
@@ -2,7 +2,6 @@ package com.example.fitnessapp.pages.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -30,7 +28,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,56 +60,68 @@ fun TrainingZonesScreen(
     var currentHeartRate by remember { mutableStateOf(150) } // Current HR for demo
     var currentPower by remember { mutableStateOf(200) } // Current power for demo
 
-    val gradientColors = listOf(
-        MaterialTheme.extendedColors.gradientPrimary,
-        MaterialTheme.extendedColors.gradientSecondary,
-        MaterialTheme.extendedColors.gradientAccent
-    )
-
     Scaffold(
         containerColor = Color.Transparent,
         topBar = {
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(brush = Brush.verticalGradient(colors = gradientColors))
-                    .statusBarsPadding()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.extendedColors.gradientPrimary,
+                                MaterialTheme.extendedColors.gradientSecondary,
+                                MaterialTheme.extendedColors.gradientAccent
+                            )
+                        )
+                    )
                     .padding(horizontal = 16.dp, vertical = 20.dp)
             ) {
-                IconButton(
-                    onClick = { navController.navigateUp() },
-                    modifier = Modifier.align(Alignment.CenterStart)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                        tint = MaterialTheme.colorScheme.onPrimary
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Text(
+                        text = "Training Zones",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontWeight = FontWeight.Bold
                     )
                 }
-
-                Text(
-                    text = "Training Zones",
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.align(Alignment.Center)
-                )
             }
         }
     ) { paddingValues ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(brush = Brush.verticalGradient(colors = gradientColors))
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.extendedColors.gradientPrimary,
+                            MaterialTheme.extendedColors.gradientSecondary,
+                            MaterialTheme.extendedColors.gradientAccent
+                        )
+                    )
+                )
         ) {
-            Surface(
+            Card(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(horizontal = 16.dp, vertical = 16.dp),
-                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-                color = MaterialTheme.extendedColors.surfaceSubtle,
-                tonalElevation = 2.dp
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
+                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -220,7 +229,7 @@ fun CurrentMetricCard(
     modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = modifier.height(136.dp),
+        modifier = modifier.height(132.dp),
         colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.12f)),
         shape = RoundedCornerShape(16.dp)
     ) {
@@ -442,7 +451,7 @@ fun TrainingSection(title: String, content: @Composable ColumnScope.() -> Unit) 
         )
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.extendedColors.surfaceSubtle),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
             modifier = Modifier.fillMaxWidth()
         ) {

--- a/app/src/main/java/com/example/fitnessapp/viewmodel/PerformanceViewModel.kt
+++ b/app/src/main/java/com/example/fitnessapp/viewmodel/PerformanceViewModel.kt
@@ -1,0 +1,458 @@
+﻿package com.example.fitnessapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.fitnessapp.api.ApiService
+import com.example.fitnessapp.api.RetrofitClient
+import com.example.fitnessapp.model.CyclingFtpResponse
+import com.example.fitnessapp.model.RunningFtpResponse
+import com.example.fitnessapp.model.SwimmingPaceResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.Response
+import java.io.IOException
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class PerformanceViewModel(
+    private val api: ApiService = RetrofitClient.retrofit.create(ApiService::class.java)
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PerformanceUiState())
+    val uiState: StateFlow<PerformanceUiState> = _uiState.asStateFlow()
+
+    fun refreshAll(token: String?) {
+        if (token.isNullOrBlank()) {
+            _uiState.update { state ->
+                state.copy(
+                    isLoading = false,
+                    globalError = "Autentificare necesar\u0103 pentru a \u00EEnc\u0103rca metricile."
+                )
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { state ->
+                val loadingMetrics = state.metrics.mapValues { (_, metricState) ->
+                    metricState.copy(isRefreshing = true, error = null)
+                }
+                state.copy(isLoading = true, globalError = null, metrics = loadingMetrics)
+            }
+
+            MetricType.values().forEach { metric ->
+                refreshMetricInternal(metric, token)
+            }
+
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
+    fun refreshMetric(metric: MetricType, token: String?) {
+        if (token.isNullOrBlank()) {
+            updateMetric(metric) { state ->
+                state.copy(
+                    isRefreshing = false,
+                    status = MetricStatus.ERROR,
+                    error = "Autentificare necesar\u0103."
+                )
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            updateMetric(metric) { it.copy(isRefreshing = true, error = null) }
+            refreshMetricInternal(metric, token)
+        }
+    }
+
+    fun recalc(metric: MetricType, token: String?) {
+        if (token.isNullOrBlank()) {
+            updateMetric(metric) { state ->
+                state.copy(
+                    isRecalculating = false,
+                    status = MetricStatus.ERROR,
+                    error = "Autentificare necesar\u0103."
+                )
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            updateMetric(metric) {
+                it.copy(
+                    isRecalculating = true,
+                    status = MetricStatus.RECALCULATING,
+                    statusMessage = "Proces\u0103m recalcularea...",
+                    error = null
+                )
+            }
+
+            try {
+                val response = api.recalc("Bearer $token", metric.apiName)
+                if (response.isSuccessful) {
+                    val body = response.body()
+                    val jobId = body?.resolvedJobId ?: response.headers()["X-Job-Id"]
+                    if (jobId.isNullOrBlank()) {
+                        updateMetric(metric) {
+                            it.copy(
+                                isRecalculating = false,
+                                status = MetricStatus.ERROR,
+                                error = body?.message ?: "Job ID indisponibil.",
+                                statusMessage = body?.message
+                            )
+                        }
+                        return@launch
+                    }
+
+                    updateMetric(metric) {
+                        it.copy(
+                            pendingJobId = jobId,
+                            statusMessage = body?.message
+                        )
+                    }
+                    pollRecalcStatus(metric, token, jobId)
+                } else {
+                    val message = response.errorMessage("Recalcularea nu a putut fi ini\u021Biat\u0103.")
+                    val targetStatus = if (response.code() == 429) MetricStatus.COOLDOWN else MetricStatus.ERROR
+                    updateMetric(metric) {
+                        it.copy(
+                            isRecalculating = false,
+                            status = targetStatus,
+                            statusMessage = if (targetStatus == MetricStatus.COOLDOWN) message else it.statusMessage,
+                            error = if (targetStatus == MetricStatus.ERROR) message else it.error,
+                            pendingJobId = null
+                        )
+                    }
+                }
+            } catch (io: IOException) {
+                updateMetric(metric) {
+                    it.copy(
+                        isRecalculating = false,
+                        status = MetricStatus.ERROR,
+                        error = "Conexiunea a e\u0219uat. \u00CEncerc\u0103 din nou.",
+                        pendingJobId = null
+                    )
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (t: Throwable) {
+                updateMetric(metric) {
+                    it.copy(
+                        isRecalculating = false,
+                        status = MetricStatus.ERROR,
+                        error = t.localizedMessage ?: "Eroare necunoscut\u0103.",
+                        pendingJobId = null
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun pollRecalcStatus(metric: MetricType, token: String, jobId: String) {
+        val maxAttempts = 15
+        repeat(maxAttempts) { attempt ->
+            if (attempt > 0) {
+                delay(2000)
+            }
+
+            val response = try {
+                api.getRecalcStatus("Bearer $token", metric.apiName, jobId)
+            } catch (io: IOException) {
+                updateMetric(metric) {
+                    it.copy(
+                        isRecalculating = false,
+                        status = MetricStatus.ERROR,
+                        error = "Nu am putut verifica statusul recalcul\u0103rii.",
+                        pendingJobId = null
+                    )
+                }
+                return
+            }
+
+            if (!response.isSuccessful) {
+                val message = response.errorMessage("Nu am putut verifica statusul recalcul\u0103rii.")
+                updateMetric(metric) {
+                    it.copy(
+                        isRecalculating = false,
+                        status = MetricStatus.ERROR,
+                        error = message,
+                        statusMessage = message,
+                        pendingJobId = null
+                    )
+                }
+                return
+            }
+
+            val body = response.body()
+            val statusValue = body?.status?.lowercase(Locale.ROOT)
+            when (statusValue) {
+                "queued", "running" -> {
+                    updateMetric(metric) {
+                        it.copy(
+                            status = MetricStatus.RECALCULATING,
+                            statusMessage = body?.message ?: "\u00CEn recalculare...",
+                            lastUpdated = formatTimestamp(body?.resolvedLastComputedAt) ?: it.lastUpdated,
+                            source = body?.source ?: it.source,
+                            cooldownUntil = body?.resolvedCooldownUntil,
+                            isRecalculating = true
+                        )
+                    }
+                }
+                "cooldown" -> {
+                    updateMetric(metric) {
+                        it.copy(
+                            status = MetricStatus.COOLDOWN,
+                            statusMessage = body?.message,
+                            cooldownUntil = body?.resolvedCooldownUntil,
+                            isRecalculating = false,
+                            pendingJobId = null
+                        )
+                    }
+                    return
+                }
+                "done" -> {
+                    updateMetric(metric) {
+                        it.copy(
+                            lastUpdated = formatTimestamp(body?.resolvedLastComputedAt) ?: it.lastUpdated,
+                            source = body?.source ?: it.source,
+                            statusMessage = body?.message,
+                            cooldownUntil = body?.resolvedCooldownUntil
+                        )
+                    }
+                    refreshMetricInternal(metric, token)
+                    updateMetric(metric) {
+                        it.copy(
+                            isRecalculating = false,
+                            status = MetricStatus.OK,
+                            statusMessage = body?.message,
+                            cooldownUntil = body?.resolvedCooldownUntil,
+                            pendingJobId = null
+                        )
+                    }
+                    return
+                }
+                "error" -> {
+                    val message = body?.message ?: "Recalcularea a e\u0219uat."
+                    updateMetric(metric) {
+                        it.copy(
+                            isRecalculating = false,
+                            status = MetricStatus.ERROR,
+                            error = message,
+                            statusMessage = message,
+                            pendingJobId = null
+                        )
+                    }
+                    return
+                }
+                else -> {
+                    updateMetric(metric) {
+                        it.copy(
+                            statusMessage = body?.message ?: it.statusMessage,
+                            lastUpdated = formatTimestamp(body?.resolvedLastComputedAt) ?: it.lastUpdated,
+                            source = body?.source ?: it.source
+                        )
+                    }
+                }
+            }
+        }
+
+        updateMetric(metric) {
+            it.copy(
+                isRecalculating = false,
+                status = MetricStatus.ERROR,
+                error = "Recalcularea dureaz\u0103 prea mult. Verific\u0103 mai t\u00E2rziu.",
+                statusMessage = "Recalcularea dureaz\u0103 prea mult.",
+                pendingJobId = null
+            )
+        }
+    }
+
+    private suspend fun refreshMetricInternal(metric: MetricType, token: String) {
+        try {
+            when (metric) {
+                MetricType.CYCLING_FTP -> handleCyclingResponse(api.getCyclingFtp("Bearer $token"))
+                MetricType.RUNNING_FTP -> handleRunningResponse(api.getRunningFtp("Bearer $token"))
+                MetricType.SWIM_CSS -> handleSwimResponse(api.getSwimmingPace("Bearer $token"))
+            }
+        } catch (io: IOException) {
+            applyNetworkError(metric)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (t: Throwable) {
+            updateMetric(metric) {
+                it.copy(
+                    isRefreshing = false,
+                    isRecalculating = false,
+                    status = MetricStatus.ERROR,
+                    error = t.localizedMessage ?: "Eroare necunoscut\u0103."
+                )
+            }
+        }
+    }
+
+    private fun handleCyclingResponse(response: Response<CyclingFtpResponse>) {
+        if (response.isSuccessful) {
+            val ftp = response.body()?.cyclingFtp ?: 0
+            updateMetric(MetricType.CYCLING_FTP) { state ->
+                val hasValue = ftp > 0
+                val targetStatus = if (hasValue) MetricStatus.OK else MetricStatus.INSUFFICIENT
+                state.copy(
+                    value = if (hasValue) ftp.toString() else "--",
+                    status = if (state.isRecalculating && state.status == MetricStatus.RECALCULATING) state.status else targetStatus,
+                    statusMessage = if (hasValue) null else "Nu avem suficiente date pentru FTP.",
+                    isRefreshing = false,
+                    error = if (hasValue) null else state.error
+                )
+            }
+        } else {
+            val message = response.errorMessage("Nu am putut ob\u021Bine FTP-ul de ciclism.")
+            applyError(MetricType.CYCLING_FTP, message, response.code())
+        }
+    }
+
+    private fun handleRunningResponse(response: Response<RunningFtpResponse>) {
+        if (response.isSuccessful) {
+            val pace = response.body()?.runningFtp.orEmpty()
+            updateMetric(MetricType.RUNNING_FTP) { state ->
+                val hasValue = pace.isNotBlank()
+                val targetStatus = if (hasValue) MetricStatus.OK else MetricStatus.INSUFFICIENT
+                state.copy(
+                    value = if (hasValue) pace else "--",
+                    status = if (state.isRecalculating && state.status == MetricStatus.RECALCULATING) state.status else targetStatus,
+                    statusMessage = if (hasValue) null else "Nu avem suficiente date pentru pace.",
+                    isRefreshing = false,
+                    error = if (hasValue) null else state.error
+                )
+            }
+        } else {
+            val message = response.errorMessage("Nu am putut ob\u021Bine pace-ul de alergare.")
+            applyError(MetricType.RUNNING_FTP, message, response.code())
+        }
+    }
+
+    private fun handleSwimResponse(response: Response<SwimmingPaceResponse>) {
+        if (response.isSuccessful) {
+            val pace = response.body()?.pace100m.orEmpty()
+            updateMetric(MetricType.SWIM_CSS) { state ->
+                val hasValue = pace.isNotBlank()
+                val targetStatus = if (hasValue) MetricStatus.OK else MetricStatus.INSUFFICIENT
+                state.copy(
+                    value = if (hasValue) pace else "--",
+                    status = if (state.isRecalculating && state.status == MetricStatus.RECALCULATING) state.status else targetStatus,
+                    statusMessage = if (hasValue) null else "Nu avem suficiente date pentru CSS.",
+                    isRefreshing = false,
+                    error = if (hasValue) null else state.error
+                )
+            }
+        } else {
+            val message = response.errorMessage("Nu am putut ob\u021Bine pace-ul de \u00EEnot.")
+            applyError(MetricType.SWIM_CSS, message, response.code())
+        }
+    }
+
+    private fun applyNetworkError(metric: MetricType) {
+        val message = "Nu am putut comunica cu serverul. Verific\u0103 conexiunea."
+        updateMetric(metric) {
+            it.copy(
+                isRefreshing = false,
+                isRecalculating = false,
+                status = MetricStatus.ERROR,
+                error = message,
+                pendingJobId = null
+            )
+        }
+        _uiState.update { state ->
+            state.copy(globalError = message)
+        }
+    }
+
+    private fun applyError(metric: MetricType, message: String, code: Int?) {
+        val status = if (code == 429) MetricStatus.COOLDOWN else MetricStatus.ERROR
+        updateMetric(metric) {
+            it.copy(
+                isRefreshing = false,
+                isRecalculating = false,
+                status = status,
+                statusMessage = if (status == MetricStatus.COOLDOWN) message else it.statusMessage,
+                error = if (status == MetricStatus.ERROR) message else it.error,
+                pendingJobId = null
+            )
+        }
+    }
+
+    private fun updateMetric(metric: MetricType, transform: (MetricCardState) -> MetricCardState) {
+        _uiState.update { state ->
+            val current = state.metrics[metric] ?: MetricCardState(metric)
+            state.copy(metrics = state.metrics + (metric to transform(current)))
+        }
+    }
+
+    private fun formatTimestamp(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        return runCatching {
+            val instant = Instant.parse(raw)
+            DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm", Locale.getDefault())
+                .withZone(ZoneId.systemDefault())
+                .format(instant)
+        }.getOrElse { raw }
+    }
+
+    private fun <T> Response<T>.errorMessage(fallback: String): String {
+        return try {
+            errorBody()?.string()?.takeIf { it.isNotBlank() } ?: fallback
+        } catch (t: Throwable) {
+            fallback
+        }
+    }
+}
+
+data class PerformanceUiState(
+    val isLoading: Boolean = false,
+    val metrics: Map<MetricType, MetricCardState> = MetricType.values().associateWith { MetricCardState(it) },
+    val globalError: String? = null
+)
+
+data class MetricCardState(
+    val metric: MetricType,
+    val label: String = metric.displayName,
+    val unit: String = metric.unit,
+    val value: String? = null,
+    val lastUpdated: String? = null,
+    val source: String? = null,
+    val status: MetricStatus = MetricStatus.UNKNOWN,
+    val statusMessage: String? = null,
+    val isRefreshing: Boolean = false,
+    val isRecalculating: Boolean = false,
+    val error: String? = null,
+    val cooldownUntil: String? = null,
+    val pendingJobId: String? = null
+)
+
+enum class MetricStatus(val displayText: String) {
+    OK("OK"),
+    RECALCULATING("\u00CEn recalculare"),
+    INSUFFICIENT("Insuficiente date"),
+    COOLDOWN("\u00CEn a\u0219teptare"),
+    ERROR("Eroare"),
+    UNKNOWN("--")
+}
+
+enum class MetricType(
+    val apiName: String,
+    val displayName: String,
+    val unit: String
+) {
+    CYCLING_FTP("cycling_ftp", "Cycling FTP", "W"),
+    RUNNING_FTP("running_ftp", "Running threshold pace", "min/km"),
+    SWIM_CSS("swim_css", "Swim CSS pace", "min/100m");
+}
+
+

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,46 @@
+﻿
+-- Performance metrics tables
+CREATE TABLE IF NOT EXISTS metric_jobs (
+    job_id CHAR(36) PRIMARY KEY,
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    status ENUM('queued','running','done','error','cooldown') NOT NULL DEFAULT 'queued',
+    message TEXT NULL,
+    last_computed_at DATETIME NULL,
+    cooldown_until DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    INDEX idx_metric_jobs_user_metric (user_id, metric, created_at)
+);
+
+CREATE TABLE IF NOT EXISTS performance_metrics (
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    value VARCHAR(32) NULL,
+    unit VARCHAR(16) NULL,
+    last_computed_at DATETIME NULL,
+    window_days INT NULL,
+    source ENUM('strava','health_connect','manual') NULL,
+    status ENUM('ok','insufficient','cooldown','error') NOT NULL DEFAULT 'ok',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, metric),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS performance_metrics_history (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    metric VARCHAR(32) NOT NULL,
+    value VARCHAR(32) NULL,
+    unit VARCHAR(16) NULL,
+    source ENUM('strava','health_connect','manual') NULL,
+    status ENUM('ok','insufficient','cooldown','error') NOT NULL,
+    window_days INT NULL,
+    last_computed_at DATETIME NULL,
+    recorded_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    INDEX idx_perf_history_user_metric (user_id, metric, recorded_at)
+);
+


### PR DESCRIPTION
## Summary
- wrap the Change Sport Metrics flow in a themed gradient container and surface card to match the app styling
- refresh the Training Zones screen with the same gradient treatment, modernized metric cards, and consistent zone sections

## Testing
- ⚠️ `./gradlew lintDebug` *(fails because the Android SDK path is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3aa0852e8832594123b32438e804f