### PR TITLE
Match More screen styling with core app gradients

### DIFF
--- a/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/CalendarScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -110,6 +112,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -857,16 +860,19 @@ fun InfiniteCalendarPage(
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
-            bottomBar = {
-                ModernBottomNavigation(navController = navController)
-            },
             snackbarHost = { SnackbarHost(snackbarHostState) },
             containerColor = Color.Transparent
         ) { paddingValues ->
+            val layoutDirection = LocalLayoutDirection.current
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
+                    // Apply only top/horizontal padding from Scaffold insets; ignore bottom so content can underlap
+                    .padding(
+                        start = paddingValues.calculateStartPadding(layoutDirection),
+                        end = paddingValues.calculateEndPadding(layoutDirection),
+                        top = paddingValues.calculateTopPadding()
+                    )
                     .background(
                         brush = Brush.verticalGradient(
                             colors = listOf(
@@ -913,7 +919,8 @@ fun InfiniteCalendarPage(
                             LazyColumn(
                                 state = listState,
                                 modifier = Modifier.fillMaxSize(),
-                                contentPadding = PaddingValues(16.dp),
+                                // Add extra bottom space so last items are not hidden under the floating bottom bar
+                                contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 120.dp),
                                 verticalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
                                 items(totalDays) { index ->
@@ -976,6 +983,11 @@ fun InfiniteCalendarPage(
                     }
                 }
             }
+        }
+
+        // Floating bottom navigation over content
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            ModernBottomNavigation(navController = navController)
         }
 
     }

--- a/app/src/main/java/com/example/fitnessapp/pages/home/SeasonScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/SeasonScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.example.fitnessapp.mock.SharedPreferencesMock
 import com.example.fitnessapp.components.TopBar
-import com.example.fitnessapp.components.BottomNavigationBar
 import com.example.fitnessapp.ui.theme.FitnessAppTheme
 
 @Composable
@@ -30,14 +29,15 @@ fun SeasonScreen(navController: NavController, authViewModel: AuthViewModel) {
     val typography = MaterialTheme.typography
     val races = authViewModel.races.observeAsState(emptyList())
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = colorScheme.surface
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
+    Box(modifier = Modifier.fillMaxSize()) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = colorScheme.surface
         ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -51,6 +51,8 @@ fun SeasonScreen(navController: NavController, authViewModel: AuthViewModel) {
                     .fillMaxSize()
                     .weight(1f)
                     .padding(horizontal = 16.dp)
+                    // Add bottom space to avoid overlap with floating bottom bar
+                    .padding(bottom = 100.dp)
             ) {
                 Spacer(modifier = Modifier.height(24.dp))
 
@@ -93,8 +95,12 @@ fun SeasonScreen(navController: NavController, authViewModel: AuthViewModel) {
                     )
                 }
             }
+            }
+        }
 
-            BottomNavigationBar(navController)
+        // Floating bottom navigation over content
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            ModernBottomNavigation(navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/fitnessapp/pages/more/MoreScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/MoreScreen.kt
@@ -10,22 +10,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import com.example.fitnessapp.ui.theme.extendedColors
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -42,6 +40,8 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.fitnessapp.R
 import com.example.fitnessapp.navigation.Routes
+import com.example.fitnessapp.pages.home.ModernBottomNavigation
+import com.example.fitnessapp.ui.theme.extendedColors
 import com.example.fitnessapp.viewmodel.AuthViewModel
 
 @Composable
@@ -60,16 +60,18 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
         MaterialTheme.extendedColors.gradientAccent
     )
 
+    val scrollState = rememberScrollState()
+
     Scaffold(
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
         bottomBar = {
-            com.example.fitnessapp.pages.home.ModernBottomNavigation(navController = navController)
+            ModernBottomNavigation(navController = navController)
         },
         containerColor = Color.Transparent
-    ) { paddingValues ->
+    ) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
                 .background(
                     brush = Brush.verticalGradient(colors = gradientColors)
                 )
@@ -77,43 +79,38 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 24.dp, vertical = 32.dp)
+                    .verticalScroll(scrollState)
+                    .padding(innerPadding)
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 24.dp, bottom = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
-                // Header
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 24.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = "More",
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = gradientContentColor
-                    )
-                }
+                Text(
+                    text = "More",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = gradientContentColor
+                )
 
-                // Content Card
                 Card(
-                    modifier = Modifier.fillMaxSize(),
-                    shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(24.dp),
                     colors = CardDefaults.cardColors(
-                        containerColor = colorScheme.surface.copy(alpha = 0.95f)
+                        containerColor = colorScheme.surface.copy(alpha = 0.98f)
                     ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                            .padding(24.dp)
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp, vertical = 28.dp),
+                        verticalArrangement = Arrangement.spacedBy(24.dp)
                     ) {
-                        // User Info
                         Column(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Image(
                                 painter = painterResource(id = R.drawable.iclogo),
@@ -122,7 +119,6 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
                                     .size(80.dp)
                                     .clip(CircleShape)
                             )
-                            Spacer(modifier = Modifier.height(12.dp))
                             Text(
                                 text = "Lucas Scott",
                                 style = MaterialTheme.typography.headlineMedium,
@@ -136,14 +132,11 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
                             )
                         }
 
-                        Spacer(modifier = Modifier.height(32.dp))
-
-                        // Sections
                         ModernSection(title = "Account") {
                             ModernSectionItem("My Account") {}
                             ModernSectionItem("Settings") {}
                             ModernSectionItem("Training Dashboard") {
-                                navController.navigate("training_dashboard")
+                                navController.navigate(Routes.TRAINING_DASHBOARD)
                             }
                             ModernSectionItem("App Integrations") {
                                 navController.navigate("app_integrations")
@@ -159,14 +152,10 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
                             }
                         }
 
-                        Spacer(modifier = Modifier.height(24.dp))
-
                         ModernSection(title = "Support") {
                             ModernSectionItem("Contact us") {}
                             ModernSectionItem("Help & Support") {}
                         }
-
-                        Spacer(modifier = Modifier.height(24.dp))
 
                         ModernSection(title = "Actions") {
                             ModernSectionItem("Log out") {
@@ -177,12 +166,11 @@ fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = nul
                                 }
                             }
                         }
-
-                        Spacer(modifier = Modifier.height(100.dp))
                     }
                 }
             }
         }
+    }
 }
 
 @Composable
@@ -192,20 +180,20 @@ fun ModernSection(title: String, content: @Composable ColumnScope.() -> Unit) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = title,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
             color = colorScheme.onSurface,
-            modifier = Modifier.padding(bottom = 12.dp)
+            modifier = Modifier.padding(bottom = 8.dp)
         )
         Card(
             shape = RoundedCornerShape(16.dp),
             colors = CardDefaults.cardColors(
-                containerColor = colorScheme.surface.copy(alpha = 0.95f)
+                containerColor = colorScheme.surfaceVariant.copy(alpha = 0.65f)
             ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            Column(modifier = Modifier.padding(8.dp), content = content)
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp), content = content)
         }
     }
 }
@@ -216,7 +204,7 @@ fun ModernSectionItem(title: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(vertical = 16.dp, horizontal = 16.dp),
+            .padding(vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(

--- a/app/src/main/java/com/example/fitnessapp/pages/more/MoreScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/more/MoreScreen.kt
@@ -4,7 +4,9 @@ import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -46,143 +48,160 @@ import com.example.fitnessapp.viewmodel.AuthViewModel
 fun MoreScreen(navController: NavController, authViewModel: AuthViewModel? = null) {
     val context = LocalContext.current
 
+    val colorScheme = MaterialTheme.colorScheme
+    val gradientContentColor = if (isSystemInDarkTheme()) {
+        colorScheme.onSurface
+    } else {
+        colorScheme.onPrimary
+    }
+    val gradientColors = listOf(
+        MaterialTheme.extendedColors.gradientPrimary,
+        MaterialTheme.extendedColors.gradientSecondary,
+        MaterialTheme.extendedColors.gradientAccent
+    )
+
     Scaffold(
         bottomBar = {
             com.example.fitnessapp.pages.home.ModernBottomNavigation(navController = navController)
         },
-        containerColor = MaterialTheme.colorScheme.surface
+        containerColor = Color.Transparent
     ) { paddingValues ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            MaterialTheme.colorScheme.primary,
-                            MaterialTheme.extendedColors.chartAltitude,
-                            MaterialTheme.extendedColors.gradientAccent
-                        )
-                    )
+                    brush = Brush.verticalGradient(colors = gradientColors)
                 )
         ) {
-            // Header
-            Row(
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp, vertical = 32.dp)
             ) {
-                Text(
-                    text = "More",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-
-            // Content Card
-            Card(
-                modifier = Modifier.fillMaxSize(),
-                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-            ) {
-                Column(
+                // Header
+                Row(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
-                        .padding(24.dp)
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // User Info
+                    Text(
+                        text = "More",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = gradientContentColor
+                    )
+                }
+
+                // Content Card
+                Card(
+                    modifier = Modifier.fillMaxSize(),
+                    shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = colorScheme.surface.copy(alpha = 0.95f)
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                ) {
                     Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(24.dp)
                     ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.iclogo),
-                            contentDescription = "Profile Picture",
-                            modifier = Modifier
-                                .size(80.dp)
-                                .clip(CircleShape)
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            text = "Lucas Scott",
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Text(
-                            text = "@lucasscott3",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.height(32.dp))
-
-                    // Sections
-                    ModernSection(title = "Account") {
-                        ModernSectionItem("My Account") {}
-                        ModernSectionItem("Settings") {}
-                        ModernSectionItem("Training Dashboard") {
-                            navController.navigate("training_dashboard")
+                        // User Info
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.iclogo),
+                                contentDescription = "Profile Picture",
+                                modifier = Modifier
+                                    .size(80.dp)
+                                    .clip(CircleShape)
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                text = "Lucas Scott",
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = "@lucasscott3",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
-                        ModernSectionItem("App Integrations") {
-                            navController.navigate("app_integrations")
-                        }
-                        ModernSectionItem("Change Sport Metrics") {
-                            navController.navigate("change_sport_metrics")
-                        }
-                        ModernSectionItem("Performance") {
-                            navController.navigate(Routes.PERFORMANCE)
-                        }
-                        ModernSectionItem("Training Zones") {
-                            navController.navigate("training_zones")
-                        }
-                    }
 
-                    Spacer(modifier = Modifier.height(24.dp))
+                        Spacer(modifier = Modifier.height(32.dp))
 
-                    ModernSection(title = "Support") {
-                        ModernSectionItem("Contact us") {}
-                        ModernSectionItem("Help & Support") {}
-                    }
-
-                    Spacer(modifier = Modifier.height(24.dp))
-
-                    ModernSection(title = "Actions") {
-                        ModernSectionItem("Log out") {
-                            authViewModel?.logout()
-                            Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()
-                            navController.navigate("login_screen") {
-                                popUpTo(0) { inclusive = true }
+                        // Sections
+                        ModernSection(title = "Account") {
+                            ModernSectionItem("My Account") {}
+                            ModernSectionItem("Settings") {}
+                            ModernSectionItem("Training Dashboard") {
+                                navController.navigate("training_dashboard")
+                            }
+                            ModernSectionItem("App Integrations") {
+                                navController.navigate("app_integrations")
+                            }
+                            ModernSectionItem("Change Sport Metrics") {
+                                navController.navigate("change_sport_metrics")
+                            }
+                            ModernSectionItem("Performance") {
+                                navController.navigate(Routes.PERFORMANCE)
+                            }
+                            ModernSectionItem("Training Zones") {
+                                navController.navigate("training_zones")
                             }
                         }
-                    }
 
-                    Spacer(modifier = Modifier.height(100.dp))
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        ModernSection(title = "Support") {
+                            ModernSectionItem("Contact us") {}
+                            ModernSectionItem("Help & Support") {}
+                        }
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        ModernSection(title = "Actions") {
+                            ModernSectionItem("Log out") {
+                                authViewModel?.logout()
+                                Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()
+                                navController.navigate("login_screen") {
+                                    popUpTo(0) { inclusive = true }
+                                }
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(100.dp))
+                    }
                 }
             }
         }
-    }
 }
 
 @Composable
 fun ModernSection(title: String, content: @Composable ColumnScope.() -> Unit) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = colorScheme.onSurface,
             modifier = Modifier.padding(bottom = 12.dp)
         )
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            colors = CardDefaults.cardColors(
+                containerColor = colorScheme.surface.copy(alpha = 0.95f)
+            ),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -203,13 +222,13 @@ fun ModernSectionItem(title: String, onClick: () -> Unit) {
         Text(
             text = title,
             style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f)
         )
         Icon(
             painter = painterResource(id = R.drawable.ic_arrow_right),
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.size(20.dp)
         )
     }


### PR DESCRIPTION
## Summary
- update the More screen scaffold to reuse the shared gradient background and contrast-aware header text
- restyle the content card and list items to rely on the shared surface palette and primary accents so the screen matches Home and Calendar

## Testing
- `./gradlew lintDebug` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c6f332688325b02cc9f75b0fcfe7