### PR TITLE
Align Strava activity detail gradient

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-10T12:36:11.643653200Z">
+        <DropdownSelection timestamp="2025-09-24T12:18:26.974150300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=ead7cec9" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,9 @@ dependencies {
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.animation:animation")
 
+    // Accompanist (for system UI controller)
+    implementation("com.google.accompanist:accompanist-systemuicontroller:0.36.0")
+
     // Shimmer effect for loading placeholders
     implementation("com.valentinilk.shimmer:compose-shimmer:1.2.0")
 

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import com.example.fitnessapp.ui.theme.extendedColors
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
@@ -69,6 +70,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -97,6 +99,7 @@ import com.example.fitnessapp.model.ActivityStreamsResponse
 import com.example.fitnessapp.model.StravaActivity
 import com.example.fitnessapp.viewmodel.StravaViewModel
 import com.example.fitnessapp.viewmodel.StravaViewModelFactory
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -573,10 +576,20 @@ fun StravaActivityDetailScreen(
 
     val colorScheme = MaterialTheme.colorScheme
     val extendedColors = MaterialTheme.extendedColors
-    val gradientContentColor = if (isSystemInDarkTheme()) {
+    val isDarkTheme = isSystemInDarkTheme()
+    val gradientContentColor = if (isDarkTheme) {
         colorScheme.onSurface
     } else {
         colorScheme.onPrimary
+    }
+    val systemUiController = rememberSystemUiController()
+    val useDarkIcons = !isDarkTheme
+
+    SideEffect {
+        systemUiController.setSystemBarsColor(
+            color = Color.Transparent,
+            darkIcons = useDarkIcons
+        )
     }
 
     var activity by remember { mutableStateOf<StravaActivity?>(null) }
@@ -657,9 +670,18 @@ fun StravaActivityDetailScreen(
                     )
                 )
             )
-            .nestedScroll(pullToRefreshState.nestedScrollConnection)
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(pullToRefreshState.nestedScrollConnection),
+            containerColor = Color.Transparent
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
             // --- Header (accessibility: guarantee 48dp min icons) ---
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -953,57 +953,60 @@ fun StravaActivityDetailScreen(
                             item {
                                 AnimatedVisibility(
                                     visible = true,
-                                    enter = fadeIn(animationSpec = tween(300, delayMillis = 300)) + slideInVertically { it/4 }
+                                    enter = fadeIn(animationSpec = tween(300, delayMillis = 300)) + slideInVertically { it / 4 }
                                 ) {
                                     Column {
                                         SectionHeader(Icons.Filled.Place, "Route Map")
-                                // ... existing RouteMapSection code ... remain unchanged
-                                val mapData = mapViewData
-                                when {
-                                    mapData?.get("gpx_data") != null && mapData["gpx_data"]!!.isNotEmpty() -> {
-                                        val gpxData = mapData["gpx_data"]!!
-                                        RouteMapSection(gpxData = gpxData)
-                                    }
 
-                                    mapData?.get("html_url") != null && mapData["html_url"]!!.isNotEmpty() -> {
-                                        RouteMapSection(htmlUrl = mapData["html_url"]!!)
-                                    }
+                                        val mapData = mapViewData
+                                        when {
+                                            mapData?.get("gpx_data") != null && mapData["gpx_data"]!!.isNotEmpty() -> {
+                                                val gpxData = mapData["gpx_data"]!!
+                                                RouteMapSection(gpxData = gpxData)
+                                            }
 
-                                    mapData?.get("map_html") != null && mapData["map_html"]!!.isNotEmpty() -> {
-                                        RouteMapSection(mapHtml = mapData["map_html"]!!)
-                                    }
+                                            mapData?.get("html_url") != null && mapData["html_url"]!!.isNotEmpty() -> {
+                                                RouteMapSection(htmlUrl = mapData["html_url"]!!)
+                                            }
 
-                                    activity?.map?.summaryPolyline != null && activity?.map?.summaryPolyline!!.isNotEmpty() -> {
-                                        RouteMapSection(polyline = activity!!.map!!.summaryPolyline!!)
-                                    }
+                                            mapData?.get("map_html") != null && mapData["map_html"]!!.isNotEmpty() -> {
+                                                RouteMapSection(mapHtml = mapData["map_html"]!!)
+                                            }
 
-                                    activity?.map?.polyline != null && activity?.map?.polyline!!.isNotEmpty() -> {
-                                        RouteMapSection(polyline = activity!!.map!!.polyline!!)
-                                    }
-                                    else -> {
-                                        Card(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(vertical = 8.dp)
-                                                .shadow(
-                                                    elevation = 4.dp,
-                                                    shape = RoundedCornerShape(20.dp)
-                                                ),
-                                            shape = RoundedCornerShape(20.dp),
-                                            border = BorderStroke(1.dp, extendedColors.borderSubtle),
-                                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-                                            elevation = CardDefaults.cardElevation(0.dp)
-                                        ) {
-                                            Text(
-                                                text = "No route data available for this activity",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                modifier = Modifier.padding(20.dp),
-                                                textAlign = TextAlign.Center
-                                            )
+                                            activity?.map?.summaryPolyline != null && activity?.map?.summaryPolyline!!.isNotEmpty() -> {
+                                                RouteMapSection(polyline = activity!!.map!!.summaryPolyline!!)
+                                            }
+
+                                            activity?.map?.polyline != null && activity?.map?.polyline!!.isNotEmpty() -> {
+                                                RouteMapSection(polyline = activity!!.map!!.polyline!!)
+                                            }
+
+                                            else -> {
+                                                Card(
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .padding(vertical = 8.dp)
+                                                        .shadow(
+                                                            elevation = 4.dp,
+                                                            shape = RoundedCornerShape(20.dp)
+                                                        ),
+                                                    shape = RoundedCornerShape(20.dp),
+                                                    border = BorderStroke(1.dp, extendedColors.borderSubtle),
+                                                    colors = CardDefaults.cardColors(
+                                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                                    ),
+                                                    elevation = CardDefaults.cardElevation(0.dp)
+                                                ) {
+                                                    Text(
+                                                        text = "No route data available for this activity",
+                                                        style = MaterialTheme.typography.bodyMedium,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                        modifier = Modifier.padding(20.dp),
+                                                        textAlign = TextAlign.Center
+                                                    )
+                                                }
+                                            }
                                         }
-                                    }
-                                }
                                     }
                                 }
                             }
@@ -1153,6 +1156,7 @@ fun StravaActivityDetailScreen(
             modifier = Modifier.align(Alignment.TopCenter)
         )
     }
+}
 }
 
 @Composable

--- a/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
+++ b/app/src/main/java/com/example/fitnessapp/pages/home/StravaActivityDetailScreen.kt
@@ -99,7 +99,9 @@ import com.example.fitnessapp.model.ActivityStreamsResponse
 import com.example.fitnessapp.model.StravaActivity
 import com.example.fitnessapp.viewmodel.StravaViewModel
 import com.example.fitnessapp.viewmodel.StravaViewModelFactory
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import androidx.core.view.WindowCompat
+import androidx.compose.ui.graphics.toArgb
+import android.app.Activity
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -582,14 +584,17 @@ fun StravaActivityDetailScreen(
     } else {
         colorScheme.onPrimary
     }
-    val systemUiController = rememberSystemUiController()
     val useDarkIcons = !isDarkTheme
 
+    val hostActivity = LocalContext.current as? Activity
     SideEffect {
-        systemUiController.setSystemBarsColor(
-            color = Color.Transparent,
-            darkIcons = useDarkIcons
-        )
+        hostActivity?.let { act ->
+            val window = act.window
+            window.statusBarColor = Color.Transparent.toArgb()
+            val controller = WindowCompat.getInsetsController(window, window.decorView)
+            controller.isAppearanceLightStatusBars = useDarkIcons
+            controller.isAppearanceLightNavigationBars = useDarkIcons
+        }
     }
 
     var activity by remember { mutableStateOf<StravaActivity?>(null) }


### PR DESCRIPTION
## Summary
- wrap StravaActivityDetailScreen content in a gradient Box and transparent Scaffold to match the home and calendar backgrounds
- set the system bars to transparent so the gradient fills the status area consistently

## Testing
- `./gradlew lintDebug` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e8bde0088325b407169e58c849f8